### PR TITLE
Expand configuration options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@ __pycache__/
 *.py[cod]
 *$py.class
 .idea/
-
+.direnv
+.envrc
 
 # C extensions
 *.so

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=["tempy"],
-    package_data={"": ["assets/*.txt"]},
+    package_data={"": ["assets/*.txt", "tempyrc"]},
     include_package_data=True,
     install_requires=["requests", "rich"],
     entry_points={"console_scripts": ["tempy=tempy.__main__:main"]},

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import pathlib
 from setuptools import setup
 
-__version__ = "1.0.7"
+__version__ = "1.0.8"
 __author__ = "Jeff Barfield"
 __author_email__ = "noprobelm@protonmail.com"
 

--- a/tempy/config.py
+++ b/tempy/config.py
@@ -99,11 +99,3 @@ class Config(dict):
             config["measurement_system"] = "imperial"
 
         return config
-
-
-if __name__ == "__main__":
-    try:
-        config = Config()
-    except Exception:
-        if Exception is not SystemExit:
-            console.print_exception(show_locals=True)

--- a/tempy/config.py
+++ b/tempy/config.py
@@ -1,47 +1,109 @@
 import os
 import argparse
+import re
+
+VALID_OPTIONS = "location", "measurement_system", "api_key"
+TEMPYRC = f"{os.path.expanduser('~')}/.config/tempyrc"
 
 
-class Config(dict):
+class TempyRC(dict):
     def __init__(self):
-        self.config_dir = f"{os.path.expanduser('~')}/.config/tempyrc"
-        args = self.parse_args()
-        super().__init__(
-            {
-                "location": args.location,
-                "measurement_system": args.measurement_system,
-                "api_key": self.api_key,
-            }
-        )
-
-    @property
-    def api_key(self):
         try:
-            with open(self.config_dir, "r") as config:
-                api_key = config.read()
-        except FileNotFoundError:
-            return None
-        return api_key
+            with open(TEMPYRC, "r") as f:
+                tempyrc = [option.split("=") for option in f.readlines()]
+                for idx in range(len(tempyrc)):
+                    tempyrc[idx][0] = tempyrc[idx][0].strip()
+                    tempyrc[idx][1] = tempyrc[idx][1].strip()
 
-    def parse_args(self):
-        parser = argparse.ArgumentParser(
-            prog="tempy",
-            usage="tempy <location> <optional args>",
-            description="Beautifully render current and near future weather data to your terminal",
-        )
-        parser.add_argument(
+        except FileNotFoundError:
+            with open(TEMPYRC, "w") as f:
+                f.write("location=\nunits=\napi_key=\n")
+            super().__init__({option: "" for option in VALID_OPTIONS})
+            return
+
+        options = {}
+        for option in tempyrc:
+            if option[0] == "location":
+                options.update({option[0]: " ".join(option[1:])})
+            elif option[0] == "units":
+                options.update({"measurement_system": option[1]})
+            elif option[0] == "api_key":
+                options.update({"api_key": option[1]})
+
+        for option in VALID_OPTIONS:
+            if option not in options.keys():
+                options.update({option: ""})
+
+        super().__init__(options)
+
+
+class Args(dict):
+    parser = argparse.ArgumentParser(
+        prog="tempy",
+        usage="tempy <location> <optional args>",
+        description="Beautifully render current and near future weather data to your terminal",
+    )
+
+    def save_config(self):
+        with open(TEMPYRC, "r") as f:
+            tempyrc = f.read()
+        for option in self:
+            if self[option] and option in VALID_OPTIONS:
+                new = f"{option}={self[option]}"
+                tempyrc = re.sub(f"{option}\S*", new, tempyrc)
+        with open(TEMPYRC, "w") as f:
+            f.write(tempyrc)
+
+    def __init__(self):
+        self.parser.add_argument(
             "location",
             nargs="*",
             help="Input a city name or US/UK/Canadian postal code",
         )
-        parser.add_argument(
-            "-u", "--units", dest="measurement_system", default="imperial"
+        self.parser.add_argument("-u", "--units", dest="measurement_system", default="")
+        self.parser.add_argument("-k", "--key", dest="api_key", default="")
+        self.parser.add_argument(
+            "-s", "--save", dest="save", action="store_true", default=False
         )
-        args = parser.parse_args()
 
-        if not args.location:
-            print(f"Error: missing required arg 'location'. Usage: {parser.usage}")
-            quit()
-
+        args = self.parser.parse_args()
         args.location = " ".join(args.location)
-        return args
+        super().__init__(
+            {
+                "location": args.location,
+                "measurement_system": args.measurement_system,
+                "api_key": args.api_key,
+            }
+        )
+
+        if args.save is True:
+            self.save_config()
+
+
+class Config(dict):
+    def __init__(self):
+        tempyrc = TempyRC()
+        args = Args()
+        super().__init__(self.set_config(tempyrc, args))
+
+    def set_config(self, tempyrc, args):
+        config = {}
+        for option in VALID_OPTIONS:
+            config[option] = args[option] or tempyrc[option]
+        if not config["location"]:
+            print(
+                f"Error: 'location' not provided in tempyrc or as command line arg. Usage: {Args.parser.usage}"
+            )
+            quit()
+        if not config["measurement_system"]:
+            config["measurement_system"] = "imperial"
+
+        return config
+
+
+if __name__ == "__main__":
+    try:
+        config = Config()
+    except Exception:
+        if Exception is not SystemExit:
+            console.print_exception(show_locals=True)

--- a/tempy/tempyrc
+++ b/tempy/tempyrc
@@ -1,2 +1,8 @@
-units imperial
-location warwick
+# tempyrc: default values tempy will use when generating a weather report. You can use one, all,
+# or none of the valid config options. If using all, simply run 'tempy' to generate your report.
+
+# Example config below
+
+# location=nyc
+# units=imperial
+# api_key=

--- a/tempy/tempyrc
+++ b/tempy/tempyrc
@@ -1,0 +1,2 @@
+units imperial
+location warwick

--- a/tempy/weather.py
+++ b/tempy/weather.py
@@ -67,7 +67,7 @@ class WeatherTable:
 class Report:
     def __init__(self, config: Config) -> None:
         self.data = Data(config["location"], config["api_key"])
-        self.measurement_system = config["measurement_system"]
+        self.units = config["units"]
 
     @property
     def location(self) -> Text:
@@ -100,7 +100,7 @@ class Report:
 
     @property
     def weather_table(self) -> WeatherTable:
-        if self.measurement_system == "imperial":
+        if self.units == "imperial":
             weather_table = WeatherTable(
                 title="Current Conditions", **self.data["weather"]["imperial"]
             )
@@ -114,7 +114,7 @@ class Report:
     @property
     def forecast_tables(self) -> List[WeatherTable]:
         forecast = self.data["forecast"]
-        if self.measurement_system == "imperial":
+        if self.units == "imperial":
             forecast_tables = [
                 WeatherTable(title="Today's Forecast", **forecast[0]["imperial"])
             ]


### PR DESCRIPTION
Added support for default options in `tempyrc`. Valid defaults are `location`, `units`, and `api_key`. None, some, or all can be used. `location` and `units` are specified in `tempyrc`, simply run `tempy` to get the weather report.

Future changes to come to support updating `tempyrc` using command line args. This should close #9 