### PR TITLE
31 add config mkdir hook

### DIFF
--- a/tempy/config.py
+++ b/tempy/config.py
@@ -19,7 +19,8 @@ class TempyRC(dict):
         except FileNotFoundError:
             parent = Path(__file__).parent
             if not os.path.isdir(parent) and os.name == "posix":
-                os.mkdir(parent)
+                CONFIGDIR = os.path.join(Path(os.path.expanduser("~")), ".config")
+                os.mkdir(CONFIGDIR)
             skel = f"{parent}/tempyrc"
             with open(skel, "r") as f:
                 skel = f.read()

--- a/tempy/config.py
+++ b/tempy/config.py
@@ -18,7 +18,7 @@ class TempyRC(dict):
 
         except FileNotFoundError:
             parent = Path(__file__).parent
-            if not os.path.isdir(parent):
+            if not os.path.isdir(parent) and os.name != "nt":
                 os.mkdir(parent)
             skel = f"{parent}/tempyrc"
             with open(skel, "r") as f:

--- a/tempy/config.py
+++ b/tempy/config.py
@@ -18,6 +18,8 @@ class TempyRC(dict):
 
         except FileNotFoundError:
             parent = Path(__file__).parent
+            if not os.path.isdir(parent):
+                os.mkdir(parent)
             skel = f"{parent}/tempyrc"
             with open(skel, "r") as f:
                 skel = f.read()

--- a/tempy/config.py
+++ b/tempy/config.py
@@ -18,7 +18,7 @@ class TempyRC(dict):
 
         except FileNotFoundError:
             parent = Path(__file__).parent
-            if not os.path.isdir(parent) and os.name != "nt":
+            if not os.path.isdir(parent) and os.name == "posix":
                 os.mkdir(parent)
             skel = f"{parent}/tempyrc"
             with open(skel, "r") as f:

--- a/tempy/config.py
+++ b/tempy/config.py
@@ -18,8 +18,8 @@ class TempyRC(dict):
 
         except FileNotFoundError:
             parent = Path(__file__).parent
-            if not os.path.isdir(parent) and os.name == "posix":
-                CONFIGDIR = os.path.join(Path(os.path.expanduser("~")), ".config")
+            CONFIGDIR = os.path.join(Path(os.path.expanduser("~")), ".config")
+            if not os.path.isdir(CONFIGDIR) and os.name == "posix":
                 os.mkdir(CONFIGDIR)
             skel = f"{parent}/tempyrc"
             with open(skel, "r") as f:


### PR DESCRIPTION
This will add logic to create `$HOME/.config` for users with `os.name == "posix"` if it doesn't already exist. This should not be a problem for `nt` systems as `$HOME\\AppData\\Roaming` should exist by default after OS install.